### PR TITLE
AHC-1220 load our taxonomy into the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.5.0] - 2019-04-12
+### ahc-sprint-21
+### Added
+  - AHC-1220
+    - Imported our taxonomy data
+    - Added info to README about our custom taxonomy.
+    
 ## [1.4.0] - 2019-03-29
 ### ahc-sprint-20
 ### Changed

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ If you've built one, let us know and we'll add it here.
 [ohanakapa]: https://github.com/codeforamerica/ohanakapa
 
 ## Taxonomy
-Out of the box, this project supports the [Open Eligibility](http://openeligibility.org)
-taxonomy. If you would like to use your own taxonomy, or add more categories to
-the Open Eligibility taxonomy, read our Wiki article on [taxonomy basics](https://github.com/codeforamerica/ohana-api/wiki/Taxonomy-basics).
+Code For America's Ohana API project supports the [Open Eligibility](http://openeligibility.org)
+taxonomy. We used their Wiki article on [taxonomy basics](https://github.com/codeforamerica/ohana-api/wiki/Taxonomy-basics) to add and extend on categories by importing our own taxonomy.
+
+Our taxonomy lives at `/data/taxonomy.csv`.
 
 ## Deploying to Heroku
 See the [Wiki](https://github.com/codeforamerica/ohana-api/wiki/How-to-deploy-the-Ohana-API-to-your-Heroku-account).

--- a/data/taxonomy.csv
+++ b/data/taxonomy.csv
@@ -1,0 +1,518 @@
+﻿bom,name,taxonomy_id,parent_id,parent_name,type,filter
+,Emergency,101,,,service,FALSE
+,Disaster Response,101-01,101,Emergency,service,FALSE
+,Emergency Cash,101-02,101,Emergency,service,FALSE
+,Help Pay for Food,101-02-01,101-02,Emergency Cash,service,FALSE
+,Help Pay for Healthcare,101-02-02,101-02,Emergency Cash,service,FALSE
+,Help Pay for Housing,101-02-03,101-02,Emergency Cash,service,FALSE
+,Help Pay for Gas,101-02-04,101-02,Emergency Cash,service,FALSE
+,Help Pay for School,101-02-05,101-02,Emergency Cash,service,FALSE
+,Help Pay for Utilities,101-02-06,101-02,Emergency Cash,service,FALSE
+,Emergency Food,101-03,101,Emergency,service,FALSE
+,Emergency Shelter,101-04,101,Emergency,service,FALSE
+,Help Find Missing Persons,101-05,101,Emergency,service,FALSE
+,Immediate Safety,101-06,101,Emergency,service,FALSE
+,Help Escape Violence,101-06-01,101-06,Immediate Safety,service,FALSE
+,Safe Housing,101-06-02,101-06,Immediate Safety,service,FALSE
+,Psychiatric Emergency Services,101-07,101,Emergency,service,FALSE
+,Food,102,,,service,FALSE
+,Community Gardens,102-01,102,Food,service,FALSE
+,Emergency Food,102-02,102,Food,service,FALSE
+,Food Delivery,102-03,102,Food,service,FALSE
+,Food Pantry,102-04,102,Food,service,FALSE
+,Free Meals,102-05,102,Food,service,FALSE
+,Help Pay for Food,102-06,102,Food,service,FALSE
+,Food Benefits,102-06-01,102-06,Help Pay for Food,service,FALSE
+,Nutrition,102-07,102,Food,service,FALSE
+,Housing,103,,,service,FALSE
+,Emergency Shelter,103-01,103,Housing,service,FALSE
+,Help Find Housing,103-02,103,Housing,service,FALSE
+,Help Pay for Housing,103-03,103,Housing,service,FALSE
+,Help Pay for Utilities,103-03-01,103-03,Help Pay for Housing,service,FALSE
+,Help Pay for Internet or Phone,103-03-02,103-03,Help Pay for Housing,service,FALSE
+,Home & Renters Insurance,103-03-03,103-03,Help Pay for Housing,service,FALSE
+,Housing Vouchers,103-03-04,103-03,Help Pay for Housing,service,FALSE
+,Maintenance & Repairs,103-04,103,Housing,service,FALSE
+,Housing Advice,103-05,103,Housing,service,FALSE
+,Foreclosure Counseling,103-05-01,103-05,Housing Advice,service,FALSE
+,Homebuyer Education,103-05-02,103-05,Housing Advice,service,FALSE
+,Residential Housing,103-06,103,Housing,service,FALSE
+,Long-Term Housing,103-06-01,103-06,Residential Housing,service,FALSE
+,Assisted Living,103-06-01-01,103-06-01,Long-Term Housing,service,FALSE
+,Independent Living,103-06-01-02,103-06-01,Long-Term Housing,service,FALSE
+,Nursing Home,103-06-01-03,103-06-01,Long-Term Housing,service,FALSE
+,Public Housing,103-06-01-04,103-06-01,Long-Term Housing,service,FALSE
+,Safe Housing,103-07,103,Housing,service,FALSE
+,Housing Legal Services,103-08,103,Housing,service,FALSE
+,Short-Term Housing,103-09,103,Housing,service,FALSE
+,Nursing Home,103-09-01,103-09,Short-Term Housing,service,FALSE
+,Sober Living,103-09-02,103-09,Short-Term Housing,service,FALSE
+,Goods,104,,,service,FALSE
+,Baby Supplies,104-01,104,Goods,service,FALSE
+,Baby Clothes,104-01-01,104-01,Baby Supplies,service,FALSE
+,Diapers & Formula,104-01-02,104-01,Baby Supplies,service,FALSE
+,Pumping Equipment,104-01-03,104-01,Baby Supplies,service,FALSE
+,Clothing,104-02,104,Goods,service,FALSE
+,Baby Clothes,104-02-01,104-02,Clothing,service,FALSE
+,Clothes for School,104-02-02,104-02,Clothing,service,FALSE
+,Clothes for Work,104-02-03,104-02,Clothing,service,FALSE
+,Clothing Vouchers,104-02-04,104-02,Clothing,service,FALSE
+,Home Goods,104-03,104,Goods,service,FALSE
+,Blankets & Fans,104-03-01,104-03,Home Goods,service,FALSE
+,Books,104-03-02,104-03,Home Goods,service,FALSE
+,Furniture,104-03-03,104-03,Home Goods,service,FALSE
+,Home Fuels,104-03-04,104-03,Home Goods,service,FALSE
+,Efficient Appliances,104-03-05,104-03,Home Goods,service,FALSE
+,Personal Care Items,104-03-06,104-03,Home Goods,service,FALSE
+,Supplies for Work,104-03-07,104-03,Home Goods,service,FALSE
+,Medical Supplies,104-04,104,Goods,service,FALSE
+,Assistive Technology,104-04-01,104-04,Medical Supplies,service,FALSE
+,Toys & Gifts,104-05,104,Goods,service,FALSE
+,Transit,105,,,service,FALSE
+,Help Pay for Transit,105-01,105,Transit,service,FALSE
+,Bus Passes,105-01-01,105-01,Help Pay for Transit,service,FALSE
+,Help Pay for Gas,105-01-02,105-01,Help Pay for Transit,service,FALSE
+,Transportation,105-02,105,Transit,service,FALSE
+,Transportation for Healthcare,105-02-01,105-02,Transportation,service,FALSE
+,Transportation for School,105-02-02,105-02,Transportation,service,FALSE
+,Health,106,,,service,FALSE
+,Substance Use Disorder,106-01,106,Health,service,TRUE
+,Treatment Setting,106-01-01,106-01,Substance Use Disorder,service,TRUE
+,Outpatient Treatment,106-01-01-01,106-01-01,Treatment Setting,service,TRUE
+,(Level 1) Regular Outpatient Treatment,106-01-01-01-01,106-01-01-01,Outpatient Treatment,service,TRUE
+,(Level 2.1) Intensive Outpatient Treatment,106-01-01-01-02,106-01-01-01,Outpatient Treatment,service,TRUE
+,(Level 2.5) Outpatient Day Treatment or partial hospitalization,106-01-01-01-03,106-01-01-01,Outpatient Treatment,service,TRUE
+,Residential Treatment,106-01-01-02,106-01-01,Treatment Setting,service,TRUE
+,Recovery Housing,106-01-01-02-01,106-01-01-02,Residential Treatment,service,TRUE
+,(Level 3.1) Transitional housing or Halfway House,106-01-01-02-02,106-01-01-02,Residential Treatment,service,TRUE
+,(Level 3.3) Residential Treatment,106-01-01-02-03,106-01-01-02,Residential Treatment,service,TRUE
+,(Level 3.5) Residential Treatment,106-01-01-02-04,106-01-01-02,Residential Treatment,service,TRUE
+,(Level 3.7) Residential Treatment,106-01-01-02-05,106-01-01-02,Residential Treatment,service,TRUE
+,Hospital Inpatient Treatment,106-01-01-03,106-01-01,Treatment Setting,service,TRUE
+,(Level 4) Hospital Inpatient,106-01-01-03-01,106-01-01-03,Hospital Inpatient Treatment,service,TRUE
+,Type of Care,106-01-02,106-01,Substance Use Disorder,service,TRUE
+,Medication-Assisted Treatment (MAT) Provided,106-01-02-01,106-01-02,Type of Care,service,TRUE
+,Opioid Use Disorders,106-01-02-01-01,106-01-02-01,Medication-Assisted Treatment (MAT) Provided,service,TRUE
+,Methadone,106-01-02-01-01-01,106-01-02-01-01,Opioid Use Disorders,service,TRUE
+,Buprenorphine,106-01-02-01-01-02,106-01-02-01-01,Opioid Use Disorders,service,TRUE
+,Naltrexone,106-01-02-01-01-03,106-01-02-01-01,Opioid Use Disorders,service,TRUE
+,Alcohol Use Disorders,106-01-02-01-02,106-01-02-01,Medication-Assisted Treatment (MAT) Provided,service,TRUE
+,Acamprosate,106-01-02-01-02-01,106-01-02-01-02,Alcohol Use Disorders,service,TRUE
+,Disulfiram,106-01-02-01-02-02,106-01-02-01-02,Alcohol Use Disorders,service,TRUE
+,Naltrexone,106-01-02-01-02-03,106-01-02-01-02,Alcohol Use Disorders,service,TRUE
+,Nicotine Use Disorders,106-01-02-01-03,106-01-02-01,Medication-Assisted Treatment (MAT) Provided,service,TRUE
+,Bupropion,106-01-02-01-03-01,106-01-02-01-03,Nicotine Use Disorders,service,TRUE
+,(NRTs) Nicotine Replacement Therapies,106-01-02-01-03-02,106-01-02-01-03,Nicotine Use Disorders,service,FALSE
+,Varenicline,106-01-02-01-03-03,106-01-02-01-03,Nicotine Use Disorders,service,TRUE
+,Withdrawal Management,106-01-02-02,106-01-02,Type of Care,service,TRUE
+,Behavioral Therapy,106-01-02-03,106-01-02,Type of Care,service,TRUE
+,(ACT) Acceptance and Commitment Therapy,106-01-02-03-01,106-01-02-03,Behavioral Therapy,service,TRUE
+,(CBT) Cognitive Behavioral Therapy,106-01-02-03-02,106-01-02-03,Behavioral Therapy,service,FALSE
+,(MAT) Medicaiton Assisted Treatment,106-01-02-03-03,106-01-02-03,Behavioral Therapy,service,FALSE
+,(MET) Motivational Enhancement Therapy,106-01-02-03-04,106-01-02-03,Behavioral Therapy,service,TRUE
+,(MI) Motivational Interviewing,106-01-02-03-05,106-01-02-03,Behavioral Therapy,service,TRUE
+,Psychoeducation,106-01-02-03-06,106-01-02-03,Behavioral Therapy,service,TRUE
+,Psychotherapy,106-01-02-03-07,106-01-02-03,Behavioral Therapy,service,TRUE
+,(RP) Relapse Prevention,106-01-02-03-08,106-01-02-03,Behavioral Therapy,service,TRUE
+,(SFGT) Solution-Focused Group Therapy,106-01-02-03-09,106-01-02-03,Behavioral Therapy,service,FALSE
+,(SE) Supportive Expressive Psychotherapy,106-01-02-03-10,106-01-02-03,Behavioral Therapy,service,TRUE
+,Trauma Informed Treatment,106-01-02-03-11,106-01-02-03,Behavioral Therapy,service,TRUE
+,Dental Care,106-02,106,Health,service,FALSE
+,End-of-Life Care,106-03,106,Health,service,FALSE
+,Bereavement,106-03-01,106-03,End-of-Life Care,service,FALSE
+,Burial & Funeral Help,106-03-02,106-03,End-of-Life Care,service,FALSE
+,Hospice,106-03-03,106-03,End-of-Life Care,service,FALSE
+,Pain Management,106-03-04,106-03,End-of-Life Care,service,FALSE
+,Health Education,106-04,106,Health,service,FALSE
+,Daily Life Skills,106-04-01,106-04,Health Education,service,FALSE
+,Disease Management,106-04-02,106-04,Health Education,service,FALSE
+,Family Planning,106-04-03,106-04,Health Education,service,FALSE
+,Nutrition,106-04-04,106-04,Health Education,service,FALSE
+,Parenting Education,106-04-05,106-04,Health Education,service,FALSE
+,Sex Education,106-04-06,106-04,Health Education,service,FALSE
+,Understand Disability,106-04-07,106-04,Health Education,service,FALSE
+,Understand Mental Health,106-04-08,106-04,Health Education,service,FALSE
+,Help Pay for Healthcare,106-05,106,Health,service,FALSE
+,Disability Benefits,106-05-01,106-05,Help Pay for Healthcare,service,FALSE
+,Discounted Healthcare,106-05-02,106-05,Help Pay for Healthcare,service,FALSE
+,Health Insurance,106-05-03,106-05,Help Pay for Healthcare,service,FALSE
+,Medical Supplies,106-05-04,106-05,Help Pay for Healthcare,service,FALSE
+,Prosthesis,106-05-04-01,106-05-04,Medical Supplies,service,FALSE
+,Durable Medical Equipment,106-05-04-02,106-05-04,Medical Supplies,service,FALSE
+,Prescription Assistance,106-05-05,106-05,Help Pay for Healthcare,service,FALSE
+,Transportation for Healthcare,106-05-06,106-05,Help Pay for Healthcare,service,FALSE
+,Medical Care,106-06,106,Health,service,FALSE
+,Alternative Medicine,106-06-01,106-06,Medical Care,service,FALSE
+,Assistive Technology,106-06-02,106-06,Medical Care,service,FALSE
+,Birth Control,106-06-03,106-06,Medical Care,service,FALSE
+,Checkup & Test,106-06-04,106-06,Medical Care,service,FALSE
+,Disability Screening,106-06-04-01,106-06-04,Checkup & Test,service,FALSE
+,Disease Screening,106-06-04-02,106-06-04,Checkup & Test,service,FALSE
+,Hearing Tests,106-06-04-03,106-06-04,Checkup & Test,service,FALSE
+,Mental Health Evaluation,106-06-04-04,106-06-04,Checkup & Test,service,FALSE
+,Pregnancy Tests,106-06-04-05,106-06-04,Checkup & Test,service,FALSE
+,Vision Tests,106-06-04-06,106-06-04,Checkup & Test,service,FALSE
+,Exercise & Fitness,106-06-05,106-06,Medical Care,service,FALSE
+,Fertility,106-06-06,106-06,Medical Care,service,FALSE
+,Maternity Care,106-06-07,106-06,Medical Care,service,FALSE
+,Skilled Nursing,106-06-08,106-06,Medical Care,service,FALSE
+,Mental Health,106-07,106,Health,service,TRUE
+,Treatment Setting,106-07-01,106-07,Mental Health,service,TRUE
+,Outpatient Treatment,106-07-01-01,106-07-01,Treatment Setting,service,TRUE
+,Integrated behavioral health programs,106-07-01-01-01,106-07-01-01,Outpatient Treatment,service,TRUE
+,Mobile treatment services,106-07-01-01-02,106-07-01-01,Outpatient Treatment,service,TRUE
+,Outpatient mental health centers,106-07-01-01-03,106-07-01-01,Outpatient Treatment,service,TRUE
+,Psychiatric day treatment programs,106-07-01-01-04,106-07-01-01,Outpatient Treatment,service,TRUE
+,Psychiatric rehabilitation program for adults,106-07-01-01-05,106-07-01-01,Outpatient Treatment,service,TRUE
+,Intensive Outpatient Treatment,106-07-01-02,106-07-01,Treatment Setting,service,TRUE
+,Intensive outpatient programs,106-07-01-02-01,106-07-01-02,Intensive Outpatient Treatment,service,TRUE
+,Partial hospital programs,106-07-01-02-02,106-07-01-02,Intensive Outpatient Treatment,service,TRUE
+,Hospital Treatment,106-07-01-03,106-07-01,Treatment Setting,service,TRUE
+,Observation service,106-07-01-03-01,106-07-01-03,Hospital Treatment,service,TRUE
+,Acute inpatient psychiatric hospitalization,106-07-01-03-02,106-07-01-03,Hospital Treatment,service,TRUE
+,Residential Treatment,106-07-01-04,106-07-01,Treatment Setting,service,TRUE
+,Group homes for adults with mental illness,106-07-01-04-01,106-07-01-04,Residential Treatment,service,TRUE
+,Residential crisis services,106-07-01-04-02,106-07-01-04,Residential Treatment,service,TRUE
+,Respite care services,106-07-01-04-03,106-07-01-04,Residential Treatment,service,TRUE
+,Pharmacotherapies Available,106-07-02,106-07,Mental Health,service,FALSE
+,Postnatal Care,106-08,106,Health,service,FALSE
+,Prevent & Treat,106-09,106,Health,service,FALSE
+,Counseling,106-09-01,106-09,Prevent & Treat,service,FALSE
+,HIV Treatment,106-09-02,106-09,Prevent & Treat,service,FALSE
+,Pain Management,106-09-03,106-09,Prevent & Treat,service,FALSE
+,Disease Management,106-09-04,106-09,Prevent & Treat,service,FALSE
+,Nursing Home,106-09-05,106-09,Prevent & Treat,service,FALSE
+,Physical Therapy,106-09-06,106-09,Prevent & Treat,service,FALSE
+,Specialized Therapy,106-09-07,106-09,Prevent & Treat,service,FALSE
+,Vaccinations,106-09-08,106-09,Prevent & Treat,service,FALSE
+,In-Home Support,106-09-09,106-09,Prevent & Treat,service,FALSE
+,Residential Treatment,106-09-10,106-09,Prevent & Treat,service,TRUE
+,Outpatient Treatment,106-09-11,106-09,Prevent & Treat,service,TRUE
+,Hospital Treatment,106-09-12,106-09,Prevent & Treat,service,TRUE
+,Primary Care,106-10,106,Health,service,FALSE
+,Drug Testing,106-11,106,Health,service,FALSE
+,Drug Testing-First Test,106-11-01,106-11,Drug Testing,service,FALSE
+,Drug Testing-Confirmatory Test,106-11-02,106-11,Drug Testing,service,FALSE
+,Drug Testing-Mobile Unit,106-11-03,106-11,Drug Testing,service,FALSE
+,Drug Testing-Failed Attempt,106-11-04,106-11,Drug Testing,service,FALSE
+,Drug Testing-Interpreter Services,106-11-05,106-11,Drug Testing,service,FALSE
+,Vision Care,106-12,106,Health,service,FALSE
+,Psychiatric Emergency Services,106-13,106,Health,service,FALSE
+,Money,107,,,service,FALSE
+,Financial Assistance,107-01,107,Money,service,FALSE
+,Help Pay for Childcare,107-01-01,107-01,Financial Assistance,service,FALSE
+,Help Pay for Food,107-01-02,107-01,Financial Assistance,service,FALSE
+,Food Benefits,107-01-02-01,107-01-02,Help Pay for Food,service,FALSE
+,Help Pay for Healthcare,107-01-03,107-01,Financial Assistance,service,FALSE
+,Disability Benefits,107-01-03-01,107-01-03,Help Pay for Healthcare,service,FALSE
+,Discounted Healthcare,107-01-03-02,107-01-03,Help Pay for Healthcare,service,FALSE
+,Health Insurance,107-01-03-03,107-01-03,Help Pay for Healthcare,service,FALSE
+,Medical Supplies,107-01-03-04,107-01-03,Help Pay for Healthcare,service,FALSE
+,Prosthesis,107-01-03-04-01,107-01-03-04,Medical Supplies,service,FALSE
+,Durable Medical Equipment,107-01-03-04-02,107-01-03-04,Medical Supplies,service,FALSE
+,Prescription Assistance,107-01-03-05,107-01-03,Help Pay for Healthcare,service,FALSE
+,Transportation for Healthcare,107-01-03-06,107-01-03,Help Pay for Healthcare,service,FALSE
+,Help Pay for Housing,107-01-04,107-01,Financial Assistance,service,FALSE
+,Help Pay for Utilities,107-01-04-01,107-01-04,Help Pay for Housing,service,FALSE
+,Home & Renters Insurance,107-01-04-02,107-01-04,Help Pay for Housing,service,FALSE
+,Maintenance & Repairs,107-01-04-03,107-01-04,Help Pay for Housing,service,FALSE
+,Help Pay for School,107-01-05,107-01,Financial Assistance,service,FALSE
+,Books,107-01-05-01,107-01-05,Help Pay for School,service,FALSE
+,Clothes for School,107-01-05-02,107-01-05,Help Pay for School,service,FALSE
+,Laundry for Students,107-01-05-03,107-01-05,Help Pay for School,service,FALSE
+,Financial Aid & Loans,107-01-05-04,107-01-05,Help Pay for School,service,FALSE
+,Transportation for School,107-01-05-05,107-01-05,Help Pay for School,service,FALSE
+,Supplies for School,107-01-05-06,107-01-05,Help Pay for School,service,FALSE
+,Help Pay for Transit,107-01-06,107-01,Financial Assistance,service,FALSE
+,Help Pay for Gas,107-01-06-01,107-01-06,Help Pay for Transit,service,FALSE
+,Bus Passes,107-01-06-02,107-01-06,Help Pay for Transit,service,FALSE
+,Help Pay for Car,107-01-06-03,107-01-06,Help Pay for Transit,service,FALSE
+,Help Pay for Work Expenses,107-01-07,107-01,Financial Assistance,service,FALSE
+,Government Benefits,107-02,107,Money,service,FALSE
+,Disability Benefits,107-02-01,107-02,Government Benefits,service,FALSE
+,Food Benefits,107-02-02,107-02,Government Benefits,service,FALSE
+,Retirement Benefits,107-02-03,107-02,Government Benefits,service,FALSE
+,Understand Government Programs,107-02-04,107-02,Government Benefits,service,FALSE
+,Unemployment Benefits,107-02-05,107-02,Government Benefits,service,FALSE
+,Financial Education,107-03,107,Money,service,FALSE
+,Credit Counseling,107-03-01,107-03,Financial Education,service,FALSE
+,Foreclosure Counseling,107-03-02,107-03,Financial Education,service,FALSE
+,Homebuyer Education,107-03-03,107-03,Financial Education,service,FALSE
+,Savings Program,107-03-04,107-03,Financial Education,service,FALSE
+,Insurance,107-04,107,Money,service,FALSE
+,Health Insurance,107-04-01,107-04,Insurance,service,FALSE
+,Home & Renters Insurance,107-04-02,107-04,Insurance,service,FALSE
+,Tax Preparation,107-05,107,Money,service,FALSE
+,Care,108,,,service,FALSE
+,Adoption & Foster Care,108-01,108,Care,service,FALSE
+,Adoption & Foster Placement,108-01-01,108-01,Adoption & Foster Care,service,FALSE
+,Adoption & Foster Parenting,108-01-02,108-01,Adoption & Foster Care,service,FALSE
+,Adoption Planning,108-01-03,108-01,Adoption & Foster Care,service,FALSE
+,Post-Adoption Support,108-01-04,108-01,Adoption & Foster Care,service,FALSE
+,Animal Welfare,108-02,108,Care,service,FALSE
+,Community Support Services,108-03,108,Care,service,FALSE
+,Computer or Internet Access,108-03-01,108-03,Community Support Services,service,FALSE
+,Daytime Care,108-04,108,Care,service,FALSE
+,Adult Daycare,108-04-01,108-04,Daytime Care,service,FALSE
+,Afterschool Care,108-04-02,108-04,Daytime Care,service,FALSE
+,Before School Care,108-04-03,108-04,Daytime Care,service,FALSE
+,Childcare,108-04-04,108-04,Daytime Care,service,FALSE
+,Help Find Childcare,108-04-04-01,108-04-04,Childcare,service,FALSE
+,Help Pay for Childcare,108-04-04-02,108-04-04,Childcare,service,FALSE
+,Day Camp,108-04-05,108-04,Daytime Care,service,FALSE
+,Preschool,108-04-06,108-04,Daytime Care,service,FALSE
+,Recreation,108-04-07,108-04,Daytime Care,service,FALSE
+,Relief for Caregivers,108-04-08,108-04,Daytime Care,service,FALSE
+,Childcare,108-05,108,Care,service,FALSE
+,Bereavement,108-05-01,108-05,Childcare,service,FALSE
+,Burial & Funeral Help,108-05-02,108-05,Childcare,service,FALSE
+,Hospice,108-05-03,108-05,Childcare,service,FALSE
+,Pain Management,108-05-04,108-05,Childcare,service,FALSE
+,Navigating the System,108-06,108,Care,service,FALSE
+,Help Fill out Forms,108-06-01,108-06,Navigating the System,service,FALSE
+,Help Find Childcare,108-06-02,108-06,Navigating the System,service,FALSE
+,Help Find Housing,108-06-03,108-06,Navigating the System,service,FALSE
+,Help Find School,108-06-04,108-06,Navigating the System,service,FALSE
+,Help Find Work,108-06-05,108-06,Navigating the System,service,FALSE
+,Physical Safety,108-07,108,Care,service,FALSE
+,Disaster Response,108-07-01,108-07,Physical Safety,service,FALSE
+,Emergency Food,108-07-02,108-07,Physical Safety,service,FALSE
+,Temporary Shelter,108-07-03,108-07,Physical Safety,service,FALSE
+,Weather Relief,108-07-03-01,108-07-03,Temporary Shelter,service,FALSE
+,Help Find Missing Persons,108-07-04,108-07,Physical Safety,service,FALSE
+,Immediate Safety,108-07-05,108-07,Physical Safety,service,FALSE
+,Help Escape Violence,108-07-05-01,108-07-05,Immediate Safety,service,FALSE
+,Safe Housing,108-07-05-02,108-07-05,Immediate Safety,service,FALSE
+,Residential Care,108-08,108,Care,service,FALSE
+,Assisted Living,108-08-01,108-08,Residential Care,service,FALSE
+,Residential Treatment,108-08-02,108-08,Residential Care,service,TRUE
+,Nursing Home,108-08-03,108-08,Residential Care,service,FALSE
+,Overnight Camp,108-08-04,108-08,Residential Care,service,FALSE
+,Support Network,108-09,108,Care,service,FALSE
+,Counseling,108-09-01,108-09,Support Network,service,FALSE
+,Help Hotlines,108-09-02,108-09,Support Network,service,FALSE
+,Home Visiting,108-09-03,108-09,Support Network,service,FALSE
+,In-Home Support,108-09-04,108-09,Support Network,service,FALSE
+,Mentoring,108-09-05,108-09,Support Network,service,FALSE
+,One-on-One Support,108-09-06,108-09,Support Network,service,FALSE
+,Peer Support,108-09-07,108-09,Support Network,service,FALSE
+,Spiritual Support,108-09-08,108-09,Support Network,service,FALSE
+,Support Groups,108-09-09,108-09,Support Network,service,FALSE
+,12-Step,108-09-09-01,108-09-09,Support Groups,service,FALSE
+,Bereavement,108-09-09-02,108-09-09,Support Groups,service,FALSE
+,Parenting Education,108-09-09-03,108-09-09,Support Groups,service,FALSE
+,Virtual Support,108-09-10,108-09,Support Network,service,FALSE
+,Education,109,,,service,FALSE
+,Help Find School,109-01,109,Education,service,FALSE
+,Help Pay for School,109-02,109,Education,service,FALSE
+,Books,109-02-01,109-02,Help Pay for School,service,FALSE
+,Clothes for School,109-02-03,109-02,Help Pay for School,service,FALSE
+,Financial Aid & Loans,109-02-04,109-02,Help Pay for School,service,FALSE
+,Transportation for School,109-02-05,109-02,Help Pay for School,service,FALSE
+,Supplies for School,109-02-06,109-02,Help Pay for School,service,FALSE
+,More Education,109-03,109,Education,service,FALSE
+,Alternative Education,109-03-01,109-03,More Education,service,FALSE
+,Disaster Preparedness & Response,109-03-02,109-03,More Education,service,FALSE
+,English as a Second Language (ESL),109-03-03,109-03,More Education,service,FALSE
+,Financial Education,109-03-04,109-03,More Education,service,FALSE
+,Credit Counseling,109-03-04-01,109-03-04,Financial Education,service,FALSE
+,Foreclosure Counseling,109-03-04-02,109-03-04,Financial Education,service,FALSE
+,Homebuyer Education,109-03-04-03,109-03-04,Financial Education,service,FALSE
+,Foreign Languages,109-03-05,109-03,More Education,service,FALSE
+,GED/High-School Equivalency,109-03-06,109-03,More Education,service,FALSE
+,Health Education,109-03-07,109-03,More Education,service,FALSE
+,Disease Management,109-03-07-01,109-03-07,Health Education,service,FALSE
+,Family Planning,109-03-07-02,109-03-07,Health Education,service,FALSE
+,Nutrition Education,109-03-07-03,109-03-07,Health Education,service,FALSE
+,Parenting Education,109-03-07-04,109-03-07,Health Education,service,FALSE
+,Sex Education,109-03-07-05,109-03-07,Health Education,service,FALSE
+,Understand Disability,109-03-07-06,109-03-07,Health Education,service,FALSE
+,Understand Mental Health,109-03-07-07,109-03-07,Health Education,service,FALSE
+,Supported Employment,109-03-08,109-03,More Education,service,FALSE
+,Special Education,109-03-09,109-03,More Education,service,FALSE
+,Tutoring,109-03-10,109-03,More Education,service,FALSE
+,Preschool,109-04,109,Education,service,FALSE
+,Screening & Exams,109-05,109,Education,service,FALSE
+,Citizenship & Immigration,109-05-01,109-05,Screening & Exams,service,FALSE
+,GED/High-School Equivalency,109-05-02,109-05,Screening & Exams,service,FALSE
+,English as a Second Language (ESL),109-05-03,109-05,Screening & Exams,service,FALSE
+,Skills & Training,109-06,109,Education,service,FALSE
+,Basic Literacy,109-06-01,109-06,Skills & Training,service,FALSE
+,Computer Class,109-06-02,109-06,Skills & Training,service,FALSE
+,Daily Life Skills,109-06-03,109-06,Skills & Training,service,FALSE
+,Interview Training,109-06-04,109-06,Skills & Training,service,FALSE
+,Resume Development,109-06-05,109-06,Skills & Training,service,FALSE
+,Skills Assessment,109-06-06,109-06,Skills & Training,service,FALSE
+,Specialized Training,109-06-07,109-06,Skills & Training,service,FALSE
+,Work,110,,,service,FALSE
+,Help Find Work,110-01,110,Work,service,FALSE
+,Job Placement,110-01-01,110-01,Help Find Work,service,FALSE
+,Supported Employment,110-01-02,110-01,Help Find Work,service,FALSE
+,Help Pay for Work Expenses,110-02,110,Work,service,FALSE
+,Clothes for Work,110-02-01,110-02,Help Pay for Work Expenses,service,FALSE
+,Retirement Benefits,110-02-02,110-02,Help Pay for Work Expenses,service,FALSE
+,Supplies for Work,110-02-03,110-02,Help Pay for Work Expenses,service,FALSE
+,Unemployment Benefits,110-02-04,110-02,Help Pay for Work Expenses,service,FALSE
+,Skills & Training,110-03,110,Work,service,FALSE
+,Basic Literacy,110-03-01,110-03,Skills & Training,service,FALSE
+,Computer Class,110-03-02,110-03,Skills & Training,service,FALSE
+,GED/High-School Equivalency,110-03-03,110-03,Skills & Training,service,FALSE
+,Interview Training,110-03-04,110-03,Skills & Training,service,FALSE
+,Resume Development,110-03-05,110-03,Skills & Training,service,FALSE
+,Skills Assessment,110-03-06,110-03,Skills & Training,service,FALSE
+,Specialized Training,110-03-07,110-03,Skills & Training,service,FALSE
+,Supported Employment,110-04,110,Work,service,FALSE
+,Workplace Rights,110-05,110,Work,service,FALSE
+,Legal,111,,,service,FALSE
+,Advocacy & Legal Aid,111-01,111,Legal,service,FALSE
+,Adoption & Foster Care,111-01-01,111-01,Advocacy & Legal Aid,service,FALSE
+,Adoption & Foster Placement,111-01-01-01,111-01-01,Adoption & Foster Care,service,FALSE
+,Adoption & Foster Parenting,111-01-01-02,111-01-01,Adoption & Foster Care,service,FALSE
+,Adoption Planning,111-01-01-03,111-01-01,Adoption & Foster Care,service,FALSE
+,Adoption Counseling,111-01-01-04,111-01-01,Adoption & Foster Care,service,FALSE
+,Post-Adoption Support,111-01-01-05,111-01-01,Adoption & Foster Care,service,FALSE
+,Citizenship & Immigration,111-01-02,111-01,Advocacy & Legal Aid,service,FALSE
+,Discrimination & Civil Rights,111-01-03,111-01,Advocacy & Legal Aid,service,FALSE
+,Guardianship,111-01-04,111-01,Advocacy & Legal Aid,service,FALSE
+,Identification Recovery,111-01-05,111-01,Advocacy & Legal Aid,service,FALSE
+,Understand Government Programs,111-01-06,111-01,Advocacy & Legal Aid,service,FALSE
+,Workplace Rights,111-01-07,111-01,Advocacy & Legal Aid,service,FALSE
+,Medical Legal,111-01-08,111-01,Advocacy & Legal Aid,service,FALSE
+,Housing Legal,111-01-09,111-01,Advocacy & Legal Aid,service,FALSE
+,Mediation,111-02,111,Legal,service,FALSE
+,Notary,111-03,111,Legal,service,FALSE
+,Representation,111-04,111,Legal,service,FALSE
+,Translation & Interpretation,111-05,111,Legal,service,FALSE
+,Age Group,112,,,situation,TRUE
+,All Ages,112-01,112,Age Group,situation,TRUE
+,Adults (31-54 years old),112-02,112,Age Group,situation,TRUE
+,Young Adults (20-30 years old),112-03,112,Age Group,situation,TRUE
+,Teens (13-19 years old),112-04,112,Age Group,situation,TRUE
+,Infants (0-1 years old),112-05,112,Age Group,situation,TRUE
+,Children (2-12 years old),112-06,112,Age Group,situation,TRUE
+,Seniors (55+ years old),112-07,112,Age Group,situation,TRUE
+,Armed Forces,113,,,situation,FALSE
+,Active Duty,113-01,113,Armed Forces,situation,FALSE
+,National Guard,113-02,113,Armed Forces,situation,FALSE
+,Veterans,113-03,113,Armed Forces,situation,FALSE
+,Citizenship,114,,,situation,FALSE
+,Immigrants,114-01,114,Citizenship,situation,FALSE
+,Refugees,114-02,114,Citizenship,situation,FALSE
+,Undocumented,114-03,114,Citizenship,situation,FALSE
+,Criminal History,115,,,situation,FALSE
+,Ex-Offenders,115-01,115,Criminal History,situation,FALSE
+,In Jail,115-02,115,Criminal History,situation,FALSE
+,Disability,116,,,situation,FALSE
+,All Disabilities,116-01,116,Disability,situation,FALSE
+,Learning Disability,116-02,116,Disability,situation,FALSE
+,Developmental Disability,116-03,116,Disability,situation,FALSE
+,Physical Disability,116-04,116,Disability,situation,FALSE
+,Intellectual Disability,116-05,116,Disability,situation,FALSE
+,Mentally Incapacitated,116-06,116,Disability,situation,FALSE
+,Limited Mobility,116-07,116,Disability,situation,FALSE
+,Hearing Impairment,116-08,116,Disability,situation,FALSE
+,Visual Impairment,116-09,116,Disability,situation,FALSE
+,Mental Illness,116-10,116,Disability,situation,TRUE
+,Education,117,,,situation,FALSE
+,Dropouts,117-01,117,Education,situation,FALSE
+,Students,117-02,117,Education,situation,FALSE
+,Employment,118,,,situation,FALSE
+,Employed,118-01,118,Employment,situation,FALSE
+,Retired,118-02,118,Employment,situation,FALSE
+,Unemployed,118-03,118,Employment,situation,FALSE
+,Gender & Sexuality,119,,,situation,TRUE
+,Women,119-01,119,Gender & Sexuality,situation,TRUE
+,Men,119-02,119,Gender & Sexuality,situation,TRUE
+,Transgender Woman,119-03,119,Gender & Sexuality,situation,TRUE
+,Transgender Man,119-04,119,Gender & Sexuality,situation,TRUE
+,Non-binary,119-05,119,Gender & Sexuality,situation,TRUE
+,LGBTQ,119-06,119,Gender & Sexuality,situation,TRUE
+,Guardianship,120,,,situation,FALSE
+,Foster Youth,120-01,120,Guardianship,situation,FALSE
+,Health Specialties,121,,,situation,FALSE
+,Pregnant,121-01,121,Health Specialties,situation,TRUE
+,Cancer,121-02,121,Health Specialties,situation,FALSE
+,Alzheimers,121-03,121,Health Specialties,situation,FALSE
+,Seizure Disorder,121-04,121,Health Specialties,situation,FALSE
+,PTSD,121-05,121,Health Specialties,situation,FALSE
+,Terminal Illness,121-06,121,Health Specialties,situation,TRUE
+,HIV/AIDS,121-07,121,Health Specialties,situation,TRUE
+,Neuromuscular Disease,121-08,121,Health Specialties,situation,FALSE
+,Tobacco/Nicotine/Smoking,121-09,121,Health Specialties,situation,TRUE
+,Opioid Use Disorder,121-10,121,Health Specialties,situation,TRUE
+,Alcohol Use Disorder,121-11,121,Health Specialties,situation,TRUE
+,Mental Illness,121-12,121,Health Specialties,situation,TRUE
+,Chronic Illness,121-13,121,Health Specialties,situation,FALSE
+,Genetic Disorder,121-14,121,Health Specialties,situation,FALSE
+,Diabetes,121-15,121,Health Specialties,situation,FALSE
+,Autism,121-16,121,Health Specialties,situation,FALSE
+,Family Friendly,122,,,situation,TRUE
+,Families with Children,122-01,122,Family Friendly,situation,TRUE
+,Single Mom,122-02,122,Family Friendly,situation,TRUE
+,Single Dad,122-03,122,Family Friendly,situation,TRUE
+,Housing,123,,,situation,FALSE
+,Home Renters,123-01,123,Housing,situation,FALSE
+,Homeless,123-02,123,Housing,situation,FALSE
+,Near Homeless,123-03,123,Housing,situation,FALSE
+,Runaways,123-04,123,Housing,situation,FALSE
+,Income,124,,,situation,FALSE
+,Benefit Recipients,124-01,124,Income,situation,FALSE
+,Low-Income,124-02,124,Income,situation,FALSE
+,Insurance Accepted,125,,,situation,TRUE
+,Uninsured (pay out of pocket),125-01,125,Insurance Accepted,situation,TRUE
+,Medicaid,125-02,125,Insurance Accepted,situation,TRUE
+,Medicare,125-03,125,Insurance Accepted,situation,TRUE
+,Tricare,125-04,125,Insurance Accepted,situation,TRUE
+,Private,125-05,125,Insurance Accepted,situation,TRUE
+,Languages,126,,,situation,TRUE
+,Spanish-Fluent Provider,126-01,126,Languages,situation,TRUE
+,ASL-Fluent Provider,126-02,126,Languages,situation,TRUE
+,Web-based Translation,126-03,126,Languages,situation,TRUE
+,Race/Ethnicity,127,,,situation,FALSE
+,African American,127-01,127,Race/Ethnicity,situation,FALSE
+,Asian,127-02,127,Race/Ethnicity,situation,FALSE
+,Latinx,127-03,127,Race/Ethnicity,situation,FALSE
+,Native American,127-04,127,Race/Ethnicity,situation,FALSE
+,Role,128,,,situation,FALSE
+,Caregivers,128-01,128,Role,situation,FALSE
+,Spouses,128-02,128,Role,situation,FALSE
+,Dependents,128-03,128,Role,situation,FALSE
+,Fathers,128-04,128,Role,situation,FALSE
+,Mothers,128-05,128,Role,situation,FALSE
+,Parents,128-06,128,Role,situation,FALSE
+,Survivors,129,,,situation,FALSE
+,All Survivors,129-01,129,Survivors,situation,FALSE
+,Trauma Survivors,129-02,129,Survivors,situation,FALSE
+,Abuse or Neglect Survivors,129-03,129,Survivors,situation,FALSE
+,Burn Survivors,129-04,129,Survivors,situation,FALSE
+,Cancer Survivors,129-05,129,Survivors,situation,FALSE
+,Childhood Cancer Survivors,129-06,129,Survivors,situation,FALSE
+,Young Adult Cancer Survivors,129-07,129,Survivors,situation,FALSE
+,Adult Cancer Survivors,129-08,129,Survivors,situation,FALSE
+,Domestic Violence Survivors,129-09,129,Survivors,situation,FALSE
+,Human Trafficking Survivors,129-10,129,Survivors,situation,FALSE
+,Natural Disaster Survivors,129-11,129,Survivors,situation,FALSE
+,Sexual Assault Survivors,129-12,129,Survivors,situation,FALSE
+,Documents Needed,130,,,situation,TRUE
+,No ID Required,130-01,130,Documents Needed,situation,TRUE
+,No Referral Required,130-02,130,Documents Needed,situation,FALSE
+,State ID Required,130-03,130,Documents Needed,situation,FALSE
+,Social Security Required,130-04,130,Documents Needed,situation,FALSE
+,Pay Stub Required,130-05,130,Documents Needed,situation,FALSE
+,Proof of Residence Required,130-06,130,Documents Needed,situation,FALSE
+,Insurance Card Required,130-07,130,Documents Needed,situation,FALSE
+,Special Hours,131,,,situation,TRUE
+,Walk-In Hours Provided,131-01,131,Special Hours,situation,TRUE
+,Evening Hours Provided,131-02,131,Special Hours,situation,TRUE
+,Weekend Hours Provided,131-03,131,Special Hours,situation,TRUE
+,Substance Use Treatment Preferences,132,,,situation,TRUE
+,Prayer Not Required,132-01,132,Substance Use Treatment Preferences,situation,TRUE
+,Smoking Allowed,132-02,132,Substance Use Treatment Preferences,situation,TRUE
+,Children Allowed,132-03,132,Substance Use Treatment Preferences,situation,TRUE
+,Pregnant Women Specialized Care,132-04,132,Substance Use Treatment Preferences,situation,TRUE
+,Forensic (Court Ordered) Clients Served,132-05,132,Substance Use Treatment Preferences,situation,TRUE
+,Co-occurring Mental Health Treatment Provided,132-06,132,Substance Use Treatment Preferences,situation,TRUE
+,Blackout Period Required,132-07,132,Substance Use Treatment Preferences,situation,TRUE
+,Cell-Phone Allowed,132-08,132,Substance Use Treatment Preferences,situation,TRUE
+,Case Management Services Provided,132-09,132,Substance Use Treatment Preferences,situation,TRUE
+,Support Groups Services Provided,132-10,132,Substance Use Treatment Preferences,situation,TRUE

--- a/db/migrate/20190304172224_add_type_to_categories.rb
+++ b/db/migrate/20190304172224_add_type_to_categories.rb
@@ -1,9 +1,5 @@
 class AddTypeToCategories < ActiveRecord::Migration[5.1]
-  def up
+  def change
     add_column :categories, :type, :string
-    Category.update_all( {type: 'service'} )
-  end
-  def down
-    remove_column :categories, :type, :string
   end
 end

--- a/db/migrate/20190409213357_add_filter_to_categories.rb
+++ b/db/migrate/20190409213357_add_filter_to_categories.rb
@@ -1,0 +1,5 @@
+class AddFilterToCategories < ActiveRecord::Migration[5.1]
+  def change
+    add_column :categories, :filter, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -194,7 +194,8 @@ CREATE TABLE public.categories (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     ancestry character varying(255),
-    type character varying
+    type character varying,
+    filter boolean DEFAULT false
 );
 
 
@@ -1331,6 +1332,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20150315202808'),
 ('20180212023953'),
 ('20190304172224'),
-('20190315143955');
+('20190315143955'),
+('20190409213357');
 
 

--- a/lib/category_presenter.rb
+++ b/lib/category_presenter.rb
@@ -19,6 +19,6 @@ CategoryPresenter = Struct.new(:row) do
 
   def category_params
     raw_params = ActionController::Parameters.new(row)
-    raw_params.permit(:taxonomy_id, :name)
+    raw_params.permit(:taxonomy_id, :name, :type, :filter)
   end
 end


### PR DESCRIPTION
First you'll need to reset the existing categories table in the db, then a `rake import:taxonomy` should load everything in, with the types and filter tags properly assigned.