### PR TITLE
AHC-1278 update capacity page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
   - AHC-1413
     - `rake category_ancestry` will ensure all ancestors of a category on a service are also applied to that service
+  - AHC-1278
+    - Added Update Capacity page for all of an admin's locations 
 ### Changed
   - AHC-1422
     - Record the original iCarol category ids on each service

--- a/app/assets/stylesheets/admin/application.css.scss
+++ b/app/assets/stylesheets/admin/application.css.scss
@@ -17,6 +17,7 @@
  */
 
 @import 'variables';
+@import "components/*";
 
 // creates styles for text in the navbar that is not a link
 .navbar-default .navbar-nav > li > a.logged-in {

--- a/app/assets/stylesheets/admin/components/service_capacity.css.scss
+++ b/app/assets/stylesheets/admin/components/service_capacity.css.scss
@@ -1,0 +1,9 @@
+.submit-button {
+  background-color: rgb(0,127,170);
+  color: white;
+  margin-top: 1em;
+}
+
+.wait-time-options {
+  width: 25em;
+}

--- a/app/assets/stylesheets/admin/components/service_capacity.css.scss
+++ b/app/assets/stylesheets/admin/components/service_capacity.css.scss
@@ -1,9 +1,46 @@
 .submit-button {
-  background-color: rgb(0,127,170);
+  background-color: #007FAA;
   color: white;
+}
+.submit-button:hover {
+  background-color: #005876;
+  color: white;
+}
+
+.main-heading {
+  color: #835EB1;
+}
+
+.locations {
+  padding-top: 2em;
+}
+
+.location-name {
+  color: #007FAA;
+}
+
+.service-name {
   margin-top: 1em;
+  margin-bottom: 1em;
+  color: #835EB1
 }
 
 .wait-time-options {
   width: 25em;
+}
+
+.updated {
+  margin-top: 1em;
+}
+.updated-label {
+  display: inline-block;
+  color: #B4B4B4;
+  margin-left: .5em;
+  font-style: italic;
+}
+
+.capacity-label {
+  padding-left: .2em;
+  margin-bottom: .2em;
+  font-size: 14px;
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,6 +15,7 @@
  */
 
 @import 'variables';
+@import "admin/components/*";
 
 // creates styles for text in the navbar that is not a link
 .navbar-default .navbar-nav > li > a.logged-in {

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -56,6 +56,12 @@ class Admin
       redirect_to admin_locations_url
     end
 
+    def capacity
+      @locations = Kaminari.paginate_array(policy_scope(Location)).
+          page(params[:page]).per(params[:per_page])
+      @locations.map!{|location| location.append(@location = Location.find(location[0])) }
+    end
+
     private
 
     # rubocop:disable MethodLength

--- a/app/controllers/admin/locations_controller.rb
+++ b/app/controllers/admin/locations_controller.rb
@@ -58,8 +58,8 @@ class Admin
 
     def capacity
       @locations = Kaminari.paginate_array(policy_scope(Location)).
-          page(params[:page]).per(params[:per_page])
-      @locations.map!{|location| location.append(@location = Location.find(location[0])) }
+                   page(params[:page]).per(params[:per_page])
+      @locations.map! { |location| location.append(@location = Location.find(location[0])) }
     end
 
     private

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -22,7 +22,7 @@ class Admin
       authorize @location
       preprocess_service
 
-      if @service.update(service_params.except(:locations))
+      if @service.update(service_params.except(:locations)) && @service.touch(:updated_at)
         redirect_to [:admin, @location, @service],
                     notice: 'Service was successfully updated.'
       else
@@ -31,12 +31,10 @@ class Admin
     end
 
     def update_capacity
-      if @service.update(service_params.except(:locations))
-        redirect_to [:admin, @location, @service],
-                    notice: 'Service was successfully updated.'
-      else
-        render :edit
-      end
+      @service = Service.find(service_capacity_params[:id])
+      @service.touch(:updated_at)
+      @service.update(service_capacity_params)
+      redirect_back(fallback_location: root_path)
     end
 
     def new
@@ -144,5 +142,8 @@ class Admin
       )
     end
     # rubocop:enable MethodLength
+    def service_capacity_params
+      params.permit(:wait_time, :id)
+    end
   end
 end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -30,6 +30,15 @@ class Admin
       end
     end
 
+    def update_capacity
+      if @service.update(service_params.except(:locations))
+        redirect_to [:admin, @location, @service],
+                    notice: 'Service was successfully updated.'
+      else
+        render :edit
+      end
+    end
+
     def new
       @location = Location.find(params[:location_id])
       @taxonomy_ids = []

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -142,6 +142,7 @@ class Admin
       )
     end
     # rubocop:enable MethodLength
+
     def service_capacity_params
       params.permit(:wait_time, :id)
     end

--- a/app/controllers/concerns/taggable.rb
+++ b/app/controllers/concerns/taggable.rb
@@ -1,7 +1,7 @@
 module Taggable
   def shift_and_split_params(params, *fields)
     fields.each do |key|
-      params[key] = params[key].shift.split(',') if params[key]
+      params[key] = params[key].shift.split(',')
     end
   end
 end

--- a/app/controllers/concerns/taggable.rb
+++ b/app/controllers/concerns/taggable.rb
@@ -1,7 +1,7 @@
 module Taggable
   def shift_and_split_params(params, *fields)
     fields.each do |key|
-      params[key] = params[key].shift.split(',')
+      params[key] = params[key].shift.split(',') if params[key]
     end
   end
 end

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -10,6 +10,10 @@
   %p
     = link_to t('admin.buttons.programs'), admin_programs_path, class: 'btn btn-primary'
 
+  - unless current_admin.super_admin?
+    %p
+      = link_to t('admin.buttons.update_capacity'), admin_capacity_path, class: 'btn btn-primary'
+
   - if current_admin.super_admin?
     %p
       = link_to t('admin.buttons.add_organization'), new_admin_organization_path, class: 'btn btn-primary'

--- a/app/views/admin/locations/capacity.html.haml
+++ b/app/views/admin/locations/capacity.html.haml
@@ -1,18 +1,22 @@
-%h3 Update Real-Time Capacity
+%h2.main-heading Update Real-Time Capacity
 %p
   Please update your service capacity below at each location. If there is no change to the capacity status, click "update status" to change the "last updated" timestamp to be the most recent time.
-- if current_admin.super_admin?
-  %p As a super admin, you have access to all locations in the database. Please make updates responsibly.
 
-%p
+%div.locations
   - @locations.each do |location|
-    %h3
+    %h3.location-name
       = location.last.name
-    %p
+    %div
       - location.last.services.each do |service|
-        %h4
+        %h4.service-name
           = service.name
-        = form_for [:admin, location.last, service], html: { class: 'edit-entry' } do |f|
-          = f.select :wait_time, options_for_select(wait_time_select_options, service.wait_time), {include_blank: 'Unknown'}, {:class => "form-control wait-time-options"}
-          = f.submit t('admin.services.capacity.update_status'), class: 'btn submit-button'
-
+        %p.capacity-label
+          = t('admin.services.capacity.capacity_status')
+        = form_tag(admin_service_update_capacity_path(location.last, service), method: :patch, class: 'edit-entry') do
+          = hidden_field_tag :service_id, service.id
+          = select_tag :wait_time, options_for_select(wait_time_select_options, service.wait_time), include_blank: 'Unknown', class: "form-control wait-time-options"
+          %div.updated
+            = submit_tag t('admin.services.capacity.update_status'), class: 'btn submit-button'
+            .updated-label
+              = t('admin.services.capacity.last_updated')
+              = service.updated_at.strftime("%m/%d/%y at %I:%M%P")

--- a/app/views/admin/locations/capacity.html.haml
+++ b/app/views/admin/locations/capacity.html.haml
@@ -1,0 +1,18 @@
+%h3 Update Real-Time Capacity
+%p
+  Please update your service capacity below at each location. If there is no change to the capacity status, click "update status" to change the "last updated" timestamp to be the most recent time.
+- if current_admin.super_admin?
+  %p As a super admin, you have access to all locations in the database. Please make updates responsibly.
+
+%p
+  - @locations.each do |location|
+    %h3
+      = location.last.name
+    %p
+      - location.last.services.each do |service|
+        %h4
+          = service.name
+        = form_for [:admin, location.last, service], html: { class: 'edit-entry' } do |f|
+          = f.select :wait_time, options_for_select(wait_time_select_options, service.wait_time), {include_blank: 'Unknown'}, {:class => "form-control wait-time-options"}
+          = f.submit t('admin.services.capacity.update_status'), class: 'btn submit-button'
+

--- a/app/views/admin/shared/_navigation_links.html.haml
+++ b/app/views/admin/shared/_navigation_links.html.haml
@@ -7,6 +7,11 @@
     = link_to t('admin.buttons.locations'), admin_locations_path
   %li
     = link_to t('admin.buttons.services'), admin_services_path
+
+  - unless current_admin.super_admin?
+    %li
+      = link_to t('admin.buttons.update_capacity'), admin_capacity_path
+      
   %li
     = link_to t('navigation.sign_out'), destroy_admin_session_path, method: 'delete'
   %ul.nav.navbar-nav.navbar-right

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,6 +302,9 @@ en:
         wait:
           description: 'How long on average does a client need to wait to receive services?'
 
+      capacity:
+        update_status: "Update Status"
+
     shared:
       forms:
         alternate_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,7 @@ en:
       organizations: 'Organizations'
       locations: 'Locations'
       services: 'Services'
+      update_capacity: 'Update Capacity'
       programs: 'Programs'
       add_organization: 'Add a new organization'
       create_organization: 'Create organization'
@@ -304,6 +305,8 @@ en:
 
       capacity:
         update_status: "Update Status"
+        capacity_status: "Capacity Status"
+        last_updated: "Last updated "
 
     shared:
       forms:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,10 +43,11 @@ Rails.application.routes.draw do
         get 'services'
       end
 
-      get 'locations/capacity', to: 'locations#capacity'
+      get 'capacity', to: 'locations#capacity'
 
       get 'locations/:location_id/services/:id', to: 'services#edit'
       get 'locations/:location_id/services/:service_id/contacts/:id', to: 'service_contacts#edit'
+      patch 'locations/:location_id/services/:id/update_capacity', to: 'services#update_capacity', as: "service_update_capacity"
       get 'locations/:location_id/contacts/:id', to: 'contacts#edit'
       get 'locations/:id', to: 'locations#edit'
       get 'organizations/:id', to: 'organizations#edit'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
         get 'services'
       end
 
+      get 'locations/capacity', to: 'locations#capacity'
+
       get 'locations/:location_id/services/:id', to: 'services#edit'
       get 'locations/:location_id/services/:service_id/contacts/:id', to: 'service_contacts#edit'
       get 'locations/:location_id/contacts/:id', to: 'contacts#edit'


### PR DESCRIPTION
Log in as an admin (not a super admin) and there should be links to the "Update Capacity" page on both the top navigation bar and the admin root "navigation" buttons (at `/admin`)

The Update Capacity page should have all of the admin's locations and those locations' services listed, with a form to update the wait time for that service. The `Last updated` label should change if the user submits the form, whether or not the status has changed.