### PR TITLE
AHC-1335: search by needs and location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [1.7.0] - 2019-05-10
 ### ahc-sprint-23
 ### Added
+  - AHC-1335
+    - Adds `/api/search_needs?location=&taxonomy_ids=` to the API
+    - Will search the categories corresponding to the received taxonomy_ids and all descendants
   - AHC-1413
     - `rake category_ancestry` will ensure all ancestors of a category on a service are also applied to that service
   - AHC-1278

--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -17,6 +17,16 @@ module Api
         render json: locations.preload(tables), each_serializer: LocationsSerializer, status: :ok
       end
 
+      def search_needs
+        locations = Location.search_needs_location(params).page(params[:page]).
+                    per(params[:per_page])
+
+        return unless stale?(etag: cache_key(locations), public: true)
+
+        generate_pagination_headers(locations)
+        render json: locations.preload(tables), each_serializer: LocationsSerializer, status: :ok
+      end
+
       def nearby
         location = Location.find(params[:location_id])
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
         end
 
         resources :search, only: :index
+        get 'search_needs', to: 'search#search_needs'
 
         resources :categories, only: :index
 


### PR DESCRIPTION
To test this...

1. use the master admin login to create a new Organization
2. add a Location to the organization with the address `8 market pl., baltimore, md 21202`
3. add a Service to the location with the Category `Health` added to the service
4. using Paw (or other similar api testing tool), hit http:localhost:8080/api/search_needs with the following url parameters: 
- location=8 market pl, baltimore, md 21213
- taxonomy_ids=106
5. confirm that the first entry received is the location you created above.

I also played around with the fact that the search actually looks for any descendants of the taxonomy as well, so while '106' is 'Health', that includes '106-01', '106-02', '106-02-01', etc.  To test that, I added a deeper category to the service, then went into the categories_services table and deleted the top level categories and only left the leaves (there's no way to do this via the UI so it probably doesn't matter??), then doing the same search above -- should still find your service :-)