### PR TITLE
AHC-1466 user can only edit wait-time capacity from dedicated page now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,14 @@
     - Record the original iCarol category ids on each service
   - AHC-1433
     - Allow admin to change the organization when editing a location
+  - AHC-1466
+    - Change wait time capacity updates service 'wait_time_updated_at' instead of 'updated_at'
 ### Removed
   - AHC-1387
     - Removed the Program button from all admin screens
-
+  - AHC-1466
+    - Removed the wait time capacity field from the service edit and create form
+    
 ## [1.6.0] - 2019-04-26
 ### ahc-sprint-22
 ### Added

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -32,7 +32,7 @@ class Admin
 
     def update_capacity
       @service = Service.find(service_capacity_params[:id])
-      @service.touch(:updated_at)
+      @service.wait_time_updated_at = Time.current
       @service.update(service_capacity_params)
       redirect_back(fallback_location: root_path)
     end

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -32,7 +32,7 @@ class Admin
 
     def update_capacity
       @service = Service.find(service_capacity_params[:id])
-      @service.wait_time_updated_at = Time.current
+      @service.touch :wait_time_updated_at
       @service.update(service_capacity_params)
       redirect_back(fallback_location: root_path)
     end

--- a/app/views/admin/locations/capacity.html.haml
+++ b/app/views/admin/locations/capacity.html.haml
@@ -17,6 +17,7 @@
           = select_tag :wait_time, options_for_select(wait_time_select_options, service.wait_time), include_blank: 'Unknown', class: "form-control wait-time-options"
           %div.updated
             = submit_tag t('admin.services.capacity.update_status'), class: 'btn submit-button'
-            .updated-label
-              = t('admin.services.capacity.last_updated')
-              = service.updated_at.strftime("%m/%d/%y at %I:%M%P")
+            - if service.wait_time_updated_at
+              .updated-label
+                = t('admin.services.capacity.last_updated')
+                = service.wait_time_updated_at.strftime("%m/%d/%y at %I:%M%P")

--- a/app/views/admin/services/forms/_fields.html.haml
+++ b/app/views/admin/services/forms/_fields.html.haml
@@ -24,6 +24,5 @@
 = render 'admin/services/forms/service_areas', f: f
 = render 'admin/services/forms/status', f: f
 = render 'admin/shared/forms/website', f: f
-= render 'admin/services/forms/wait', f: f, service: service
 = render 'admin/services/forms/categories', f: f
 = render 'admin/services/forms/keywords', f: f, service: service

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module OhanaApi
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run 'rake -D time' for a list of tasks for finding time zone names. Default is UTC.
-    config.time_zone = 'Pacific Time (US & Canada)'
+    config.time_zone = 'Eastern Time (US & Canada)'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/spec/features/admin/services/create_service_spec.rb
+++ b/spec/features/admin/services/create_service_spec.rb
@@ -166,15 +166,6 @@ feature 'Create a new service' do
     expect(find_field('service_website').value).to eq 'http://ruby.com'
   end
 
-  scenario 'with wait_time' do
-    fill_in_required_service_fields
-    select 'Available Today', from: 'service_wait_time'
-    click_button I18n.t('admin.buttons.create_service')
-    click_link 'New VRS Services service'
-
-    expect(find_field('service_wait_time').value).to eq 'available_today'
-  end
-
   scenario 'when adding categories', :js do
     emergency = Category.create!(name: 'Emergency', taxonomy_id: '101', type: 'service')
     emergency.children.create!(name: 'Disaster Response', taxonomy_id: '101-01', type: 'service')

--- a/spec/features/admin/services/update_wait_time_spec.rb
+++ b/spec/features/admin/services/update_wait_time_spec.rb
@@ -7,11 +7,11 @@ feature 'Update wait_time' do
     visit '/admin/locations/vrs-services'
   end
 
-  scenario 'with valid wait_time' do
-    click_link 'Literacy Program'
-    select 'Available Today', from: 'service_wait_time'
-    click_button I18n.t('admin.buttons.save_changes')
-    expect(page).to have_content 'Service was successfully updated.'
-    expect(find_field('service_wait_time').value).to eq 'available_today'
-  end
+  # scenario 'with valid wait_time' do
+  #   click_link 'Literacy Program'
+  #   select 'Available Today', from: 'service_wait_time'
+  #   click_button I18n.t('admin.buttons.save_changes')
+  #   expect(page).to have_content 'Service was successfully updated.'
+  #   expect(find_field('service_wait_time').value).to eq 'available_today'
+  # end
 end

--- a/spec/views/_wait.html.haml_spec.rb
+++ b/spec/views/_wait.html.haml_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe 'admin/services/forms/_wait', type: :view do
     render template: 'admin/services/edit'
   end
 
-  it 'will show the wait time label' do
-    expect(rendered).to have_content('Wait Time')
-  end
-
-  it 'will show the Unknown wait time option' do
-    expect(rendered).to have_content('Unknown')
-  end
-
-  it 'will show the Available Today wait time option' do
-    expect(rendered).to have_content('Available Today')
-  end
-
-  it 'will show the Next Day Service wait time option' do
-    expect(rendered).to have_content('Next Day Service')
-  end
-
-  it 'will show the 2-3 Day Wait wait time option' do
-    expect(rendered).to have_content('2-3 Day Wait')
-  end
-
-  it 'will show the 1 Week Wait wait time option' do
-    expect(rendered).to have_content('1 Week Wait')
-  end
+  # it 'will show the wait time label' do
+  #   expect(rendered).to have_content('Wait Time')
+  # end
+  #
+  # it 'will show the Unknown wait time option' do
+  #   expect(rendered).to have_content('Unknown')
+  # end
+  #
+  # it 'will show the Available Today wait time option' do
+  #   expect(rendered).to have_content('Available Today')
+  # end
+  #
+  # it 'will show the Next Day Service wait time option' do
+  #   expect(rendered).to have_content('Next Day Service')
+  # end
+  #
+  # it 'will show the 2-3 Day Wait wait time option' do
+  #   expect(rendered).to have_content('2-3 Day Wait')
+  # end
+  #
+  # it 'will show the 1 Week Wait wait time option' do
+  #   expect(rendered).to have_content('1 Week Wait')
+  # end
 end


### PR DESCRIPTION
Also updates service 'wait_time_updated_at' instead of 'updated_at', and I corrected the application's time zone to Eastern.